### PR TITLE
update `layerRect()` to handle inconsistent `leading` and `spaceBefore`/`spaceAfter` paragraph props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "aefunctions",
       "version": "2.0.3",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Current `layerRect()` will calculate `lineGap` based on `sourceText.style.leading` and multiply by number of lines:

https://github.com/motiondeveloper/aefunctions/blob/a6a777177fe0e0acb5451a0f0f265fecd41153a1/src/index.ts#L300-L307

But, if a text layer has per-character styles applied (via UI, or via expressions from something like [`style-parser`](https://github.com/motiondeveloper/style-parser)) we'd need to calculate `lineGap` based on the styles at each line's starting character index value.

This PR introduces a new option `consistentLeading` that when set to `false` will calculate as described. (Open to a better option name/API here, haha!)

Additionally, the `spaceBefore` and `spaceAfter` paragraph props can affect the height of a given text layer. This PR adds the appropriate height given said paragraph spacing as well.

Here's an example project to check out: [aefunctions-layerRect.zip](https://github.com/user-attachments/files/18138382/aefunctions-layerRect.zip)

Note: In this PR, I no longer use `textCount()` to determine `numLines`. I found the regexp in this PR to be more consistent/expected—let me know if it breaks an edge case I haven't considered!